### PR TITLE
fix: validate local domains creating service

### DIFF
--- a/src/validators/http-service-validator.ts
+++ b/src/validators/http-service-validator.ts
@@ -2,6 +2,18 @@ import { ObjectSchema } from 'joi';
 import Joi from './joi-validator';
 import { FilterQueryDto } from '../repositories/filters/repository-query-filter';
 import { nslookupResolvesServerIp } from './domain-validator';
+import Container from 'typedi';
+import { DomainRepository } from '../repositories/domain-repository';
+
+export const validateServiceDomain = async (c: string): Promise<string> => {
+  const domain = await Container.get(DomainRepository).getDomainByName(c);
+
+  if (domain) {
+    return c;
+  }
+
+  return nslookupResolvesServerIp(c);
+};
 
 export interface HttpServiceType {
   name: string;
@@ -40,7 +52,7 @@ export const httpServiceValidator: ObjectSchema<HttpServiceType> = Joi.object({
   domain: Joi.string()
     .domain()
     .allow(null, '')
-    .external(nslookupResolvesServerIp)
+    .external(validateServiceDomain)
     .optional(),
   pathLocation: Joi.string().pattern(/^\/.*/).optional(),
   backendProto: Joi.string().valid('http', 'https').allow(null).optional(),

--- a/src/validators/tcp-service-validator.ts
+++ b/src/validators/tcp-service-validator.ts
@@ -2,7 +2,7 @@ import { ObjectSchema } from 'joi';
 import Joi from './joi-validator';
 import config from '../config';
 import { FilterQueryDto } from '../repositories/filters/repository-query-filter';
-import { nslookupResolvesServerIp } from './domain-validator';
+import { validateServiceDomain } from './http-service-validator';
 
 export interface TcpServiceType {
   name: string;
@@ -42,7 +42,7 @@ export const tcpServiceValidator: ObjectSchema<TcpServiceType> = Joi.object({
   domain: Joi.string()
     .domain()
     .allow(null, '')
-    .external(nslookupResolvesServerIp)
+    .external(validateServiceDomain)
     .optional(),
   proto: Joi.string().valid('tcp', 'udp').allow(null).optional(),
   backendHost: Joi.string().allow(null).invalid('localhost').optional(),


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Brief description of the change:

- Validate local domains without nslookup verification

---

## Checklist

- [X] Code compiles and runs correctly
- [X] Linting and formatting pass
- [X] Tests have been added/updated (if applicable)
- [ ] Docs have been updated (if applicable)
