### PR TITLE
fix: change wiredoor backendHost from localhost to 127.0.0.1

### DIFF
--- a/frontend/src/components/services/HTTPServiceModalForm.vue
+++ b/frontend/src/components/services/HTTPServiceModalForm.vue
@@ -87,7 +87,7 @@ const {
             description="Define the public path where the service will be available (e.g., /api). The combination of Public Domain + Public Path must be unique."
             :errors="errors"
             :tabindex="2"
-            :disabled="(node?.isLocal && formData.backendHost === 'localhost')"
+            :disabled="(node?.isLocal && formData.backendHost === '127.0.0.1')"
           />
         </div>
         <div>
@@ -125,7 +125,7 @@ const {
                     { label: 'http://', value: 'http' },
                     { label: 'https://', value: 'https' },
                   ]"
-                  :disabled="(node?.isLocal && formData.backendHost === 'localhost')"
+                  :disabled="(node?.isLocal && formData.backendHost === '127.0.0.1')"
                   :tabindex="4"
                 />
               </div>
@@ -134,7 +134,7 @@ const {
                   v-model="formData.backendHost"
                   field="backendHost"
                   placeholder="host/ip"
-                  :disabled="!(node?.isGateway || node?.isLocal) || (node?.isLocal && formData.backendHost === 'localhost')"
+                  :disabled="!(node?.isGateway || node?.isLocal) || (node?.isLocal && formData.backendHost === '127.0.0.1')"
                   :tabindex="5"
                 />
               </div>
@@ -151,7 +151,7 @@ const {
             description="Specify the port where the service is running on the specified hostname or node (e.g., 8080)."
             :errors="errors"
             :tabindex="6"
-            :disabled="(node?.isLocal && formData.backendHost === 'localhost')"
+            :disabled="(node?.isLocal && formData.backendHost === '127.0.0.1')"
             required
             @input="(e) => validateField('backendPort')"
           />

--- a/src/database/seeders/1745979577159-UpdateLocalWiredoorService.ts
+++ b/src/database/seeders/1745979577159-UpdateLocalWiredoorService.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateLocalWiredoorService1745979577159
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE "http_services"
+        SET "backendHost" = '127.0.0.1'
+        WHERE "name" = 'Wiredoor_APP' AND "backendHost" = 'localhost'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE "http_services"
+        SET "backendHost" = 'localhost'
+        WHERE "name" = 'Wiredoor_APP' AND "backendHost" = '127.0.0.1'
+    `);
+  }
+}

--- a/src/services/http-services-service.ts
+++ b/src/services/http-services-service.ts
@@ -97,7 +97,7 @@ export class HttpServicesService extends BaseServices {
   ): Promise<HttpService> {
     const old = await this.getHttpService(id, ['node']);
 
-    if (old.node.isLocal && old.backendHost === 'localhost') {
+    if (old.node.isLocal && old.backendHost === '127.0.0.1') {
       params = {
         name: params.domain,
         domain: params.domain,
@@ -157,7 +157,7 @@ export class HttpServicesService extends BaseServices {
   public async deleteHttpService(id: number): Promise<string> {
     const httpService = await this.getHttpService(id, ['node']);
 
-    if (httpService.node.isLocal && httpService.backendHost === 'localhost') {
+    if (httpService.node.isLocal && httpService.backendHost === '127.0.0.1') {
       throw new BadRequestError(`Wiredoor APP can't be deleted`);
     }
 

--- a/src/validators/http-service-validator.ts
+++ b/src/validators/http-service-validator.ts
@@ -56,7 +56,10 @@ export const httpServiceValidator: ObjectSchema<HttpServiceType> = Joi.object({
     .optional(),
   pathLocation: Joi.string().pattern(/^\/.*/).optional(),
   backendProto: Joi.string().valid('http', 'https').allow(null).optional(),
-  backendHost: Joi.string().allow(null).optional(),
+  backendHost: Joi.string()
+    .allow(null)
+    .invalid('localhost', '127.0.0.1')
+    .optional(),
   backendPort: Joi.number().port().optional(),
   allowedIps: Joi.array()
     .items(Joi.string().ip({ cidr: 'optional' }).optional())

--- a/src/validators/tcp-service-validator.ts
+++ b/src/validators/tcp-service-validator.ts
@@ -45,7 +45,10 @@ export const tcpServiceValidator: ObjectSchema<TcpServiceType> = Joi.object({
     .external(validateServiceDomain)
     .optional(),
   proto: Joi.string().valid('tcp', 'udp').allow(null).optional(),
-  backendHost: Joi.string().allow(null).invalid('localhost').optional(),
+  backendHost: Joi.string()
+    .allow(null)
+    .invalid('localhost', '127.0.0.1')
+    .optional(),
   backendPort: Joi.number().port().required(),
   port: Joi.number()
     .min(config.server.port_range ? +config.server.port_range.split('-')[0] : 0)


### PR DESCRIPTION
… 502 error in some environments

# 🚀 Pull Request

## Summary

Brief description of the change:

- Change Wiredoor service host from localhost to 127.0.0.1 to avoid 502 error in some environments

---

## Related Issues

Closes #20 

---

## Checklist

- [X] Code compiles and runs correctly
- [X] Linting and formatting pass
- [X] Tests have been added/updated (if applicable)
- [] Docs have been updated (if applicable)
