### PR TITLE
fix: set classes to see node details in dark mode

### DIFF
--- a/frontend/src/components/nodes/NodeDetails.vue
+++ b/frontend/src/components/nodes/NodeDetails.vue
@@ -221,7 +221,7 @@ onUnmounted(async () => {
                       <div class="text-left">Client IP</div>
                     </td>
                     <td class="py-2">
-                      <div class="font-medium text-right text-gray-800">
+                      <div class="font-medium text-right text-gray-800 dark:text-gray-400">
                         {{ node.clientIp || '-' }}
                       </div>
                     </td>
@@ -232,7 +232,7 @@ onUnmounted(async () => {
                       <div class="text-left">Latest Handshake</div>
                     </td>
                     <td class="py-2">
-                      <div class="font-medium text-right text-gray-800">
+                      <div class="font-medium text-right text-gray-800 dark:text-gray-400">
                         {{ getLatestHS(node.latestHandshakeTimestamp) }}
                       </div>
                     </td>
@@ -243,7 +243,7 @@ onUnmounted(async () => {
                       <div class="text-left">Transmitted</div>
                     </td>
                     <td class="py-2">
-                      <div class="font-medium text-right text-gray-800">
+                      <div class="font-medium text-right text-gray-800 dark:text-gray-400">
                         {{ getTraffic(node.transferTx) }}
                       </div>
                     </td>
@@ -254,7 +254,7 @@ onUnmounted(async () => {
                       <div class="text-left">Received</div>
                     </td>
                     <td class="py-2">
-                      <div class="font-medium text-right text-gray-800">
+                      <div class="font-medium text-right text-gray-800 dark:text-gray-400">
                         {{ getTraffic(node.transferRx) }}
                       </div>
                     </td>
@@ -264,7 +264,7 @@ onUnmounted(async () => {
                       <div class="text-left">Send all internet traffic through the VPN</div>
                     </td>
                     <td class="py-2">
-                      <div class="font-medium text-right text-gray-800">
+                      <div class="font-medium text-right text-gray-800 dark:text-gray-400">
                         {{ node.allowInternet ? 'Yes' : 'No' }}
                       </div>
                     </td>

--- a/frontend/src/components/services/ServiceInfo.vue
+++ b/frontend/src/components/services/ServiceInfo.vue
@@ -24,7 +24,7 @@ const { isOpen, closeDialog, service } = useServiceInfo()
 
       <div class="flex justify-between items-center mt-5">
         <strong>Backend:</strong>
-        <span class="text-gray-700">{{ (service as HttpService).backendProto || (service as TcpService).proto }}://{{ service.backendHost || 'localhost' }}:{{ service.backendPort }}</span>
+        <span class="text-gray-700 dark:text-gray-500">{{ (service as HttpService).backendProto || (service as TcpService).proto }}://{{ service.backendHost || 'localhost' }}:{{ service.backendPort }}</span>
       </div>
 
       <div v-if="service.allowedIps" class="flex justify-between items-center mt-5">


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Brief description of the change:

- Set classes to make node details visible in dark mode

---

## Related Issues

Closes #75 

---

## Checklist

- [X] Code compiles and runs correctly
- [X] Linting and formatting pass
- [X] Tests have been added/updated (if applicable)
- [] Docs have been updated (if applicable)
