### PR TITLE
Run as non-root (security hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,11 +168,11 @@ jobs:
         run: |
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             echo "TAG=latest" >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_REF}" == "refs/heads/development" ]]; then
-            echo "TAG=dev" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG_NAME="${GITHUB_REF#refs/tags/}"
             echo "TAG=${TAG_NAME}" >> $GITHUB_OUTPUT
+          else
+            echo "TAG=dev-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           fi
 
       - name: Install Trivy

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION=1.0.0
 ENV TZ=America/New_York
 
 RUN apk add --no-cache \
-  dpkg iptables gawk tzdata \
+  iptables tzdata supercronic \
   wireguard-tools conntrack-tools tcpdump nginx nginx-mod-stream supervisor openssl certbot libcap sudo \
   && apk add --no-cache fluent-bit --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV TZ=America/New_York
 
 RUN apk add --no-cache \
   dpkg iptables gawk tzdata \
-  wireguard-tools conntrack-tools tcpdump nginx nginx-mod-stream supervisor openssl certbot libcap \
+  wireguard-tools conntrack-tools tcpdump nginx nginx-mod-stream supervisor openssl certbot libcap sudo \
   && apk add --no-cache fluent-bit --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 COPY docker/resources/crontabs /etc/crontabs/
@@ -16,22 +16,29 @@ COPY --chown=node:node docker/resources/nginx /etc/nginx/
 COPY docker/resources/openssl /etc/openssl/
 COPY docker/resources/supervisor /etc/supervisor/
 COPY docker/resources/fluent-bit /etc/fluent-bit/
+COPY docker/resources/sudoers.d /etc/sudoers.d/
 
 RUN mkdir -p /var/run/supervisor /var/log/supervisor \
   && chown -R node:node /var/run/supervisor /var/log/supervisor \
-  && mkdir -p /var/run/nginx /var/log/nginx /etc/nginx/{ssl,stream.d} /var/www/letsencrypt \
-  && chown -R node:node /var/run/nginx /var/log/nginx /etc/nginx/{ssl,stream.d} /var/www/letsencrypt \
-  && mkdir -P /etc/letsencrypt /var/lib/letsencrypt /var/log/letsencrypt \
+  && rm -f /etc/supervisord.conf \
+  && ln -s /etc/supervisor/supervisord.conf /etc/supervisord.conf \
+  && mkdir -p /var/run/nginx /var/log/nginx /var/lib/nginx /etc/nginx/locations /etc/nginx/ssl /etc/nginx/stream.d /var/www/letsencrypt \
+  && chown -R node:node /var/run/nginx /var/log/nginx /var/lib/nginx /etc/nginx/locations /etc/nginx/ssl /etc/nginx/stream.d /var/www/letsencrypt \
+  && rm -f /etc/nginx/conf.d/stream.conf \
+  && mkdir -p /etc/letsencrypt /var/lib/letsencrypt /var/log/letsencrypt \
   && chown -R node:node /etc/letsencrypt /var/lib/letsencrypt /var/log/letsencrypt \
   && mkdir -p /data \
   && chown -R node:node /data \
+  && mkdir -p /etc/wireguard \
+  && chown -R node:node /etc/wireguard \
+  && touch /etc/environment \
+  && chown node:node /etc/environment \
   && touch /var/log/supervisor/app.stdout.log \
   && ln -sf /dev/stdout /var/log/supervisor/app.stdout.log \
   && touch /var/log/supervisor/app.stderr.log \
   && ln -sf /dev/stderr /var/log/supervisor/app.stderr.log
 
-RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-  && setcap 'cap_net_admin,cap_net_raw+ep' /usr/bin/tcpdump /sbin/ip /usr/bin/wg /usr/sbin/iptables
+RUN setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 FROM base AS dev-container
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,23 +8,30 @@ ENV TZ=America/New_York
 
 RUN apk add --no-cache \
   dpkg iptables gawk tzdata \
-  wireguard-tools conntrack-tools tcpdump nginx nginx-mod-stream supervisor openssl certbot \
+  wireguard-tools conntrack-tools tcpdump nginx nginx-mod-stream supervisor openssl certbot libcap \
   && apk add --no-cache fluent-bit --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 COPY docker/resources/crontabs /etc/crontabs/
-COPY docker/resources/nginx /etc/nginx/
+COPY --chown=node:node docker/resources/nginx /etc/nginx/
 COPY docker/resources/openssl /etc/openssl/
 COPY docker/resources/supervisor /etc/supervisor/
 COPY docker/resources/fluent-bit /etc/fluent-bit/
 
-RUN mkdir -p /var/log/supervisor \
-  && mkdir -p /var/www/letsencrypt \
+RUN mkdir -p /var/run/supervisor /var/log/supervisor \
+  && chown -R node:node /var/run/supervisor /var/log/supervisor \
+  && mkdir -p /var/run/nginx /var/log/nginx /etc/nginx/{ssl,stream.d} /var/www/letsencrypt \
+  && chown -R node:node /var/run/nginx /var/log/nginx /etc/nginx/{ssl,stream.d} /var/www/letsencrypt \
+  && mkdir -P /etc/letsencrypt /var/lib/letsencrypt /var/log/letsencrypt \
+  && chown -R node:node /etc/letsencrypt /var/lib/letsencrypt /var/log/letsencrypt \
   && mkdir -p /data \
-  && rm -f /etc/nginx/conf.d/stream.conf \
+  && chown -R node:node /data \
   && touch /var/log/supervisor/app.stdout.log \
   && ln -sf /dev/stdout /var/log/supervisor/app.stdout.log \
   && touch /var/log/supervisor/app.stderr.log \
   && ln -sf /dev/stderr /var/log/supervisor/app.stderr.log
+
+RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+  && setcap 'cap_net_admin,cap_net_raw+ep' /usr/bin/tcpdump /sbin/ip /usr/bin/wg /usr/sbin/iptables
 
 FROM base AS dev-container
 
@@ -91,6 +98,8 @@ COPY --chown=node:node --from=uibuild /app/dist /app/dist/public
 COPY --chown=node:node docker/resources/init.sh /init.sh
 
 RUN chmod +x /init.sh
+
+USER node
 
 VOLUME ["/etc/letsencrypt","/data"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 ARG VERSION=1.0.0
 
 ENV TZ=America/New_York
+ENV PYTHONWARNINGS="ignore:::pkg_resources"
 
 RUN apk add --no-cache \
   iptables tzdata supercronic \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,9 +39,8 @@ RUN mkdir -p /var/run/supervisor /var/log/supervisor \
   && touch /var/log/supervisor/app.stdout.log \
   && ln -sf /dev/stdout /var/log/supervisor/app.stdout.log \
   && touch /var/log/supervisor/app.stderr.log \
-  && ln -sf /dev/stderr /var/log/supervisor/app.stderr.log
-
-RUN setcap cap_net_bind_service=+ep /usr/sbin/nginx
+  && ln -sf /dev/stderr /var/log/supervisor/app.stderr.log \
+  && setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 FROM base AS dev-container
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 FROM base AS dev-container
 
-RUN apk add --update git rsync nano curl bash sqlite \
+RUN apk add --update git rsync nano curl bash sqlite supervisor certbot \
   && rm -f /etc/supervisor/conf.d/app.conf
 
 CMD [ "bash", "-c", "/usr/bin/supervisord -ns -c /etc/supervisor/supervisord.conf" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,3 @@
-FROM python:3.12-alpine AS python-base
-
-ARG OAUTH2PROXY_VERSION="7.12.0"
-
-RUN apk add --no-cache py3-pip build-base curl \
-  && curl -sL https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v${OAUTH2PROXY_VERSION}/oauth2-proxy-v${OAUTH2PROXY_VERSION}.linux-amd64.tar.gz -o /tmp/oauth2-proxy.tar.gz \
-  && tar -xzf /tmp/oauth2-proxy.tar.gz \
-  && mv ./oauth2-proxy-v${OAUTH2PROXY_VERSION}.linux-amd64/oauth2-proxy /usr/bin/oauth2-proxy \
-  && pip install --upgrade pip setuptools wheel \
-  && pip install --no-cache-dir supervisor \
-  && python3 -m venv /opt/certbot/ \
-  && /opt/certbot/bin/pip install --upgrade pip \
-  && /opt/certbot/bin/pip install certbot \
-  && mkdir -p /install/site-packages \
-  && cp -r /usr/local/lib/python3.12/site-packages/supervisor /install/site-packages/ \
-  && cp -r /usr/local/lib/python3.12/site-packages/supervisor-*.dist-info /install/site-packages/
-
 FROM node:22-alpine AS base
 
 WORKDIR /app
@@ -24,18 +7,12 @@ ARG VERSION=1.0.0
 ENV TZ=America/New_York
 ENV PYTHONWARNINGS="ignore:::pkg_resources"
 
-COPY --from=python-base /install/site-packages/ /usr/lib/python3.12/site-packages/
-COPY --from=python-base /usr/local/bin/supervisord /usr/local/bin/supervisorctl /usr/bin/
-
-COPY --from=python-base /opt/certbot /opt/certbot
-
 RUN apk add --no-cache \
   iptables tzdata supercronic \
   wireguard-tools conntrack-tools tcpdump nginx nginx-mod-stream python3 openssl libcap sudo \
   && apk add --no-cache fluent-bit --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
   && ln -s /usr/bin/python3.12 /usr/local/bin/python3.12 \
-  && ln -s /usr/bin/python3.12 /usr/local/bin/python3 \
-  && ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+  && ln -s /usr/bin/python3.12 /usr/local/bin/python3
 
 COPY docker/resources/crontabs /etc/crontabs/
 COPY --chown=node:node docker/resources/nginx /etc/nginx/
@@ -81,6 +58,23 @@ RUN npm i
 
 COPY --chown=node:node . .
 
+FROM python:3.12-alpine AS python-base
+
+ARG OAUTH2PROXY_VERSION="7.12.0"
+
+RUN apk add --no-cache py3-pip build-base curl \
+  && curl -sL https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v${OAUTH2PROXY_VERSION}/oauth2-proxy-v${OAUTH2PROXY_VERSION}.linux-amd64.tar.gz -o /tmp/oauth2-proxy.tar.gz \
+  && tar -xzf /tmp/oauth2-proxy.tar.gz \
+  && mv ./oauth2-proxy-v${OAUTH2PROXY_VERSION}.linux-amd64/oauth2-proxy /usr/bin/oauth2-proxy \
+  && pip install --upgrade pip setuptools wheel \
+  && pip install --no-cache-dir supervisor \
+  && python3 -m venv /opt/certbot/ \
+  && /opt/certbot/bin/pip install --upgrade pip \
+  && /opt/certbot/bin/pip install certbot \
+  && mkdir -p /install/site-packages \
+  && cp -r /usr/local/lib/python3.12/site-packages/supervisor /install/site-packages/ \
+  && cp -r /usr/local/lib/python3.12/site-packages/supervisor-*.dist-info /install/site-packages/
+
 FROM base AS build
 
 COPY --chown=node:node package*.json ./
@@ -118,17 +112,19 @@ LABEL org.opencontainers.image.licenses=MIT \
       org.opencontainers.image.version=${VERSION}
 
 COPY --from=python-base /usr/bin/oauth2-proxy /usr/bin/oauth2-proxy
+COPY --from=python-base /install/site-packages/ /usr/lib/python3.12/site-packages/
+COPY --from=python-base /usr/local/bin/supervisord /usr/local/bin/supervisorctl /usr/bin/
+COPY --from=python-base /opt/certbot /opt/certbot
 COPY --chown=node:node --from=build /app/node_modules /app/node_modules
 COPY --chown=node:node --from=build /app/dist /app/dist
 COPY --chown=node:node --from=uibuild /app/dist /app/dist/public
 COPY --chown=node:node docker/resources/init.sh /init.sh
 
-RUN chmod +x /init.sh
+RUN chmod +x /init.sh \
+  && ln -s /opt/certbot/bin/certbot /usr/bin/certbot
 
 USER node
 
 VOLUME ["/etc/letsencrypt","/data"]
 
 CMD [ "/init.sh" ]
-
-# USER node

--- a/docker/resources/crontabs/node
+++ b/docker/resources/crontabs/node
@@ -1,0 +1,2 @@
+0 0 * * * /usr/bin/certbot renew --quiet --post-hook "/usr/sbin/nginx -s reload" >> /var/log/cron.log 2>&1
+* * * * * /usr/local/bin/node /app/dist/src/scripts/disable-expired-services.js >> /var/log/supervisor/tasks.log 2>&1

--- a/docker/resources/crontabs/root
+++ b/docker/resources/crontabs/root
@@ -1,2 +1,0 @@
-0 0 * * * /usr/bin/certbot renew --quiet --post-hook "/usr/sbin/nginx -s reload" >> /var/log/cron.log 2>&1
-* * * * * node /app/dist/src/scripts/disable-expired-services.js >> /var/log/supervisor/tasks.log 2>&1

--- a/docker/resources/init.sh
+++ b/docker/resources/init.sh
@@ -2,7 +2,6 @@
 set -e
 
 mkdir -p /data/ssl
-mkdir -p /etc/nginx/ssl
 
 openssl genpkey -algorithm RSA -out /data/ssl/privkey.key >> /dev/null 2>&1
 openssl req -new -key /data/ssl/privkey.key -out /data/ssl/default.csr -config /etc/openssl/openssl.cnf >> /dev/null 2>&1

--- a/docker/resources/nginx/conf.d/default.conf
+++ b/docker/resources/nginx/conf.d/default.conf
@@ -1,5 +1,7 @@
 server {
   listen 80 default_server;
+  listen [::]:80 default_server;
+
   server_name _;
 
   location /.well-known/acme-challenge/ {
@@ -20,6 +22,8 @@ server {
 
 server {
   listen 443 ssl default_server;
+  listen [::]:443 ssl default_server;
+
   server_name _;
 
   ssl_certificate         /etc/nginx/ssl/cert.crt;

--- a/docker/resources/nginx/error_pages/50x.html
+++ b/docker/resources/nginx/error_pages/50x.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="robots" content="noindex">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Wiredoor - Service Unavailable</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background-color: #0f0f0f;
+      color: #f5f5f5;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+
+    h1 {
+      font-size: 3rem;
+      margin-bottom: 0.5rem;
+      color: #1EB1D8;
+    }
+
+    a {
+      color: #f5f5f5;
+      opacity: 0.6;
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    p {
+      font-size: 1.2rem;
+      opacity: 0.7;
+      max-width: 500px;
+      text-align: center;
+    }
+
+    .footer {
+      position: absolute;
+      bottom: 1rem;
+      font-size: 0.8rem;
+      opacity: 0.3;
+    }
+  </style>
+</head>
+<body>
+    <h1>Ops! 502 — Bad Gateway</h1>
+    <p>Wiredoor was unable to reach the backend service. The service may be down or misconfigured. Please try again later.</p>
+    <div class="footer">Powered by <strong>Wiredoor</strong></div>
+</body>
+</html>

--- a/docker/resources/nginx/nginx.conf
+++ b/docker/resources/nginx/nginx.conf
@@ -2,6 +2,7 @@ pid /run/nginx/nginx.pid;
 worker_processes auto;
 load_module modules/ngx_stream_module.so;
 include /etc/nginx/modules-enabled/*.conf;
+user node;
 
 # only log critical errors
 error_log /var/log/nginx/error.log crit;

--- a/docker/resources/nginx/nginx.conf
+++ b/docker/resources/nginx/nginx.conf
@@ -2,7 +2,7 @@ pid /run/nginx/nginx.pid;
 worker_processes auto;
 load_module modules/ngx_stream_module.so;
 include /etc/nginx/modules-enabled/*.conf;
-user node;
+# user node;
 
 # only log critical errors
 error_log /var/log/nginx/error.log crit;
@@ -86,4 +86,8 @@ http {
 
   include /etc/nginx/conf.d/*.conf;
   # include /etc/nginx/sites-available/*;
+
+  proxy_intercept_errors  on;
+
+  error_page 404 502 503 504 /error/$status.html;
 }

--- a/docker/resources/nginx/partials/error_pages.conf
+++ b/docker/resources/nginx/partials/error_pages.conf
@@ -1,6 +1,0 @@
-# error_page 400 401 403 404 500 502 503 504 /error/$status.html;
-error_page 404 502 503 504 /error/$status.html;
-location /error/ {
-  root /etc/nginx/error_pages;
-  internal;
-}

--- a/docker/resources/nginx/partials/security.conf
+++ b/docker/resources/nginx/partials/security.conf
@@ -11,6 +11,13 @@ ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers HIGH:!aNULL:!MD5;
 ssl_prefer_server_ciphers on;
 
+location /error/ {
+  internal;
+  alias /etc/nginx/error_pages/;
+  default_type text/html;
+  try_files $uri /error/50x.html;
+}
+
 # . files
 location ~ /\.(?!well-known) {
   deny all;

--- a/docker/resources/sudoers.d/wg-quick
+++ b/docker/resources/sudoers.d/wg-quick
@@ -1,0 +1,1 @@
+node ALL=(root) NOPASSWD: /usr/bin/wg-quick, /usr/bin/wg, /sbin/ip, /usr/sbin/iptables, /usr/sbin/ip6tables, /usr/sbin/xtables-nft-multi

--- a/docker/resources/supervisor/conf.d/cron.conf
+++ b/docker/resources/supervisor/conf.d/cron.conf
@@ -1,0 +1,12 @@
+[program:cron]
+command=/usr/bin/supercronic /etc/crontabs/node
+stopsignal=KILL
+autostart=true
+autorestart=true
+startsecs=1
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0

--- a/docker/resources/supervisor/conf.d/crond.conf
+++ b/docker/resources/supervisor/conf.d/crond.conf
@@ -1,5 +1,5 @@
 [program:crond]
-command=crond -f -l 8
-user=root
+command=crond -f -c /etc/crontabs
+stopsignal=KILL
 autostart=true
 autorestart=true

--- a/docker/resources/supervisor/conf.d/crond.conf
+++ b/docker/resources/supervisor/conf.d/crond.conf
@@ -1,5 +1,0 @@
-[program:crond]
-command=crond -f -c /etc/crontabs
-stopsignal=KILL
-autostart=true
-autorestart=true

--- a/docker/resources/supervisor/supervisord.conf
+++ b/docker/resources/supervisor/supervisord.conf
@@ -1,17 +1,17 @@
 [unix_http_server]
-file=/run/supervisord.sock
+file=/var/run/supervisor/supervisord.sock
 chmod=0700
 
 [supervisord]
 logfile=/var/log/supervisor/supervisord.log
-pidfile=/run/supervisord.pid
+pidfile=/var/run/supervisor/supervisord.pid
 childlogdir=/var/log/supervisor
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///run/supervisord.sock
+serverurl=unix:///var/run/supervisor/supervisord.sock
 
 [include]
 files = /etc/supervisor/conf.d/*.conf

--- a/src/providers/node-monitor.ts
+++ b/src/providers/node-monitor.ts
@@ -4,6 +4,7 @@ import { NodeRepository } from '../repositories/node-repository';
 import { logger } from './logger';
 
 interface PingResult {
+  lastPingTs: number;
   reachable: boolean;
   latency: number;
 }
@@ -26,9 +27,11 @@ export function startPing(): void {
       });
       await Promise.all(
         nodes.map(async (node) => {
+          const prevPing = cache.get(node.address);
           const start = Date.now();
           const reachable = await Net.isReachable(node.address);
           cache.set(node.address, {
+            lastPingTs: reachable ? Date.now() : prevPing?.lastPingTs || null,
             reachable,
             latency: Date.now() - start,
           });

--- a/src/services/proxy-server/conf/nginx-server-conf.ts
+++ b/src/services/proxy-server/conf/nginx-server-conf.ts
@@ -55,6 +55,14 @@ export class NginxServerConf extends NginxConf {
     return this;
   }
 
+  setDefaultPages(): NginxServerConf {
+    this.addBlock('# Default pages', '');
+    this.addBlock('root', '/etc/nginx/default_pages/');
+    this.addBlock('index', 'index.html');
+
+    return this;
+  }
+
   setStreamSSLCertificate(sslPair: SSLCerts): NginxServerConf {
     this.setSSLCertificate(sslPair);
     this.addBlock('include', 'partials/stream_ssl.conf');

--- a/src/services/proxy-server/nginx-domain-service.ts
+++ b/src/services/proxy-server/nginx-domain-service.ts
@@ -7,17 +7,18 @@ import { SSLManager } from './ssl-manager';
 
 export class NginxDomainService extends NginxService {
   async create(domain: Domain, restart = true): Promise<boolean> {
-    const domianName = domain.domain;
+    const domainName = domain.domain;
 
     const serverConf = new NginxServerConf();
 
     serverConf
       .setListen('443 ssl')
       .setListen('[::]:443 ssl')
-      .setServerName(domianName)
-      .setAccessLog(ServerUtils.getLogFilePath(domianName, 'access.log'))
-      .setErrorLog(ServerUtils.getLogFilePath(domianName, 'error.log'))
-      .setHttpSSLCertificates(domain.sslPair);
+      .setServerName(domainName)
+      .setAccessLog(ServerUtils.getLogFilePath(domainName, 'access.log'))
+      .setErrorLog(ServerUtils.getLogFilePath(domainName, 'error.log'))
+      .setHttpSSLCertificates(domain.sslPair)
+      .setDefaultPages();
 
     if (domain.oauth2ServicePort) {
       const oauth2conf: NginxLocationConf = new NginxLocationConf();
@@ -67,12 +68,12 @@ export class NginxDomainService extends NginxService {
       );
     }
 
-    serverConf.includeLocations(`${domianName}/*.conf`);
+    serverConf.includeLocations(`${domainName}/*.conf`);
 
-    const confFile = `/etc/nginx/conf.d/${domianName}.conf`;
+    const confFile = `/etc/nginx/conf.d/${domainName}.conf`;
     await this.saveFile(confFile, serverConf.getNginxConf());
 
-    await this.addDefaultMainLocation(domianName);
+    await this.addDefaultMainLocation(domainName);
 
     return this.checkAndReload(confFile, restart);
   }

--- a/src/services/wireguard/wireguard-service.ts
+++ b/src/services/wireguard/wireguard-service.ts
@@ -252,6 +252,12 @@ class WireguardService {
       pingStatus.reachable
     ) {
       status = 'online';
+    } else if (
+      pingStatus &&
+      pingStatus.lastPingTs === null &&
+      Date.now() / 1000 - runtimeInfo.latestHandshake < 120
+    ) {
+      status = 'online';
     }
 
     return {

--- a/src/utils/wg-cli.ts
+++ b/src/utils/wg-cli.ts
@@ -55,12 +55,14 @@ export default class WGCli {
    * @param {string} cfg - Config name
    */
   static async syncConf(cfg = 'wg0'): Promise<void> {
-    await CLI.exec(`wg syncconf ${cfg} <(wg-quick strip ${cfg})`);
+    await CLI.exec(
+      `sudo wg-quick strip ${cfg} | sudo wg syncconf ${cfg} /dev/stdin`,
+    );
   }
 
   static async quickUp(cfg = 'wg0'): Promise<void> {
     try {
-      await CLI.exec(`wg-quick up ${cfg}`);
+      await CLI.exec(`sudo wg-quick up ${cfg}`);
     } catch (e) {
       throw e;
     }
@@ -68,7 +70,7 @@ export default class WGCli {
 
   static async quickDown(cfg = 'wg0'): Promise<void> {
     try {
-      await CLI.exec(`wg-quick down ${cfg}`);
+      await CLI.exec(`sudo wg-quick down ${cfg}`);
     } catch {
       // fail to down interface
     }
@@ -88,7 +90,9 @@ export default class WGCli {
     cfg = 'wg0',
   ): Promise<RuntimeInfo | null> {
     try {
-      const { stdout } = await CLI.exec(`wg show ${cfg} dump | grep ${peer}`);
+      const { stdout } = await CLI.exec(
+        `sudo wg show ${cfg} dump | grep ${peer}`,
+      );
 
       if (!stdout) {
         return null;
@@ -104,7 +108,7 @@ export default class WGCli {
 
   static async dumpRunTimeInfo(cfg = 'wg0'): Promise<RuntimeInfo[]> {
     try {
-      const { stdout } = await CLI.exec(`wg show ${cfg} dump`);
+      const { stdout } = await CLI.exec(`sudo wg show ${cfg} dump`);
 
       if (!stdout) {
         return [];


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

- Container and services now run as non-root by default.
- `sudo` added to the image to execute required WireGuard/networking commands when needed.

## What changed

- Default user switched from `root` to `non-root`.
- Internal scripts updated to work with least-privilege execution.

---

## Checklist

- [x] Code compiles and runs correctly
- [x] Linting and formatting pass
- [ ] Tests have been added/updated (if applicable)
- [ ] Docs have been updated (if applicable)
