### PR TITLE
Dev/stoufiler/fix ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request' && secrets.WIREDOOR_DOCKER_HUB_TOKEN != ''
+        if: github.event_name != 'pull_request' && env.DOCKER_HUB_TOKEN != ''
+        env:
+          DOCKER_HUB_TOKEN: ${{ secrets.WIREDOOR_DOCKER_HUB_TOKEN }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.WIREDOOR_DOCKER_HUB_USERNAME }}
@@ -172,11 +174,13 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
+        env:
+          DOCKER_HUB_TOKEN: ${{ secrets.WIREDOOR_DOCKER_HUB_TOKEN }}
         uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            ${{ (secrets.WIREDOOR_DOCKER_HUB_TOKEN != '' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) && 'docker.io/wiredoor/wiredoor' || '' }}
+            ${{ (env.DOCKER_HUB_TOKEN != '' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) && 'docker.io/wiredoor/wiredoor' || '' }}
           tags: |
             type=ref,event=tag
             type=raw,value=latest,enable={{ is_default_branch }}


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Brief description of the change:

When forked the repository it was complicated to run the CI because it asked password etc..

So I've updated the CI to use some actions instead of writing big code block

You will see several time this kind of step : 

```yaml
- name: Prepare Image Name
        run: |
          echo "IMAGE_NAME=$(echo ghcr.io/${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
```

I needed to add it because my github name starts with an Uppercase and we cannot push an image with an uppercase

On my side it works well and CI completion time is like you have (around 10 minutes)

This PR will publish the container image on ghcr repository and if the DOCKER_HUB secrets are presents it will be published on Docker Hub

You can have a look on a CI run on my fork [here](https://github.com/Stoufiler/wiredoor/actions/runs/21788083676)

---

## Related Issues

No one

---

## Checklist

- [X] Code compiles and runs correctly
- [X] Linting and formatting pass
- [X] Tests have been added/updated (if applicable)
- [ ] Docs have been updated (if applicable)

PS : This PR has been generated using AI (Gemini 3 Pro) and may contains potential errors