### PR TITLE
Allow multiple HTTP services to reuse the same backend target

### DIFF
--- a/frontend/src/components/services/HTTPServiceModalForm.vue
+++ b/frontend/src/components/services/HTTPServiceModalForm.vue
@@ -85,7 +85,7 @@ const authAvailable = computed(() => {
             label="Public Domain"
             :options="domainOptions"
             placeholder="example.com"
-            description="Specify or select a public domain to access this service (e.g., service.domain.com). If left empty, the service will only be accessible by IP."
+            description="Specify or select a public domain to access this service (e.g., service.domain.com). The public domain + path combination must stay unique. If left empty, the service will only be accessible by IP."
             :errors="errors"
             :tabindex="1"
             allowCustomValue
@@ -98,7 +98,7 @@ const authAvailable = computed(() => {
             field="pathLocation"
             label="Public HTTP Path"
             placeholder="/"
-            description="Define the public path where the service will be available (e.g., /api). The combination of Public Domain + Public Path must be unique."
+            description="Define the public path where the service will be available (e.g., /api). The combination of Public Domain + Public Path must be unique, even when multiple services reuse the same backend."
             :errors="errors"
             :tabindex="2"
             :disabled="node?.isLocal && formData.backendHost === '127.0.0.1'"
@@ -117,11 +117,11 @@ const authAvailable = computed(() => {
               <div class="text-sm">
                 <p>
                   Choose the protocol (http:// or https://) and specify the backend service
-                  hostname.
+                  hostname or IP.
                 </p>
                 <p>
-                  If the node is a gateway, specify the hostname or IP of the backend service (e.g.,
-                  192.168.1.100 or internal.service.com).
+                  Multiple HTTP services can point to the same backend target. This is useful when
+                  one internal reverse proxy, such as Traefik, routes many domains.
                 </p>
                 <p>
                   If the node is not a gateway, this field is disabled, and only local services on
@@ -165,7 +165,7 @@ const authAvailable = computed(() => {
             type="number"
             label="Backend Port"
             placeholder="80"
-            description="Specify the port where the service is running on the specified hostname or node (e.g., 8080)."
+            description="Specify the port where the backend service is running on the specified hostname or node (e.g., 8080). This backend may be shared by multiple HTTP services."
             :errors="errors"
             :tabindex="6"
             :disabled="node?.isLocal && formData.backendHost === '127.0.0.1'"

--- a/frontend/src/components/services/HttpServicesCard.vue
+++ b/frontend/src/components/services/HttpServicesCard.vue
@@ -136,7 +136,7 @@ const editService = (service: HttpService) => {
               >
               <br />
               <span class="inline-block">
-                Proxy ->
+                Upstream ->
                 <span class="font-medium">
                   {{
                     row.backendHost

--- a/frontend/src/components/services/ServiceInfo.vue
+++ b/frontend/src/components/services/ServiceInfo.vue
@@ -23,7 +23,7 @@ const { isOpen, closeDialog, service } = useServiceInfo()
       </div>
 
       <div class="flex justify-between items-center mt-5">
-        <strong>Backend:</strong>
+        <strong>Backend Target:</strong>
         <span class="text-gray-700 dark:text-gray-500">{{ (service as HttpService).backendProto || (service as TcpService).proto }}://{{ service.backendHost || 'localhost' }}:{{ service.backendPort }}</span>
       </div>
 

--- a/frontend/src/composables/services/useHttpServiceForm.ts
+++ b/frontend/src/composables/services/useHttpServiceForm.ts
@@ -52,7 +52,7 @@ export function useHttpServiceForm() {
       id,
       initialData,
       title: 'Expose HTTP Service on Node',
-      description: `This form allows you to expose an HTTP service from a node connected to Wiredoor. The configuration will be applied via Nginx, enabling access through a unique public domain and path combination.`,
+      description: `This form allows you to expose an HTTP service from a node connected to Wiredoor. Each service keeps one public domain and path, but many services may point to the same backend host and port.`,
       endpoint: `/api/services/${node.value.id}/http`,
       onSubmit: async (form) => {
         openServiceInfo(form)

--- a/src/database/models/http-service.ts
+++ b/src/database/models/http-service.ts
@@ -14,9 +14,6 @@ import config from '../../config';
 import { getTtlFromExpiresAt } from '../../utils/ttl-utils';
 
 @Entity('http_services')
-@Index('UX_service_port_unique', ['backendPort', 'backendHost', 'nodeId'], {
-  unique: true,
-})
 @Index('UX_domain_path_unique', ['domain', 'pathLocation'], { unique: true })
 export class HttpService {
   @PrimaryGeneratedColumn()

--- a/src/database/seeders/1760193711990-UpdateHttpServiceBackendTargetIndex.ts
+++ b/src/database/seeders/1760193711990-UpdateHttpServiceBackendTargetIndex.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateHttpServiceBackendTargetIndex1760193711990
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "service_port_unique"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "service_port_unique" ON "http_services" ("backendPort", "backendHost", "nodeId")`,
+    );
+  }
+}

--- a/src/tests/nodes/http-services-service.test.ts
+++ b/src/tests/nodes/http-services-service.test.ts
@@ -282,6 +282,60 @@ describe('HTTP Services Service', () => {
         ),
       );
     });
+
+    it('should allow multiple HTTP services to share the same backend target', async () => {
+      const sharedBackend = {
+        backendHost: '10.99.80.131',
+        backendPort: 443,
+        backendProto: 'https',
+      } as const;
+
+      const serviceData1 = {
+        ...makeHttpServiceData({
+          ...sharedBackend,
+          name: 'argocd',
+          domain: 'argocd.example.test',
+          pathLocation: '/',
+        }),
+        backendHost: sharedBackend.backendHost,
+      };
+      const serviceData2 = {
+        ...makeHttpServiceData({
+          ...sharedBackend,
+          name: 'headlamp',
+          domain: 'headlamp.example.test',
+          pathLocation: '/',
+        }),
+        backendHost: sharedBackend.backendHost,
+      };
+
+      mockNslookup.mockImplementation(
+        jest.fn(() => {
+          return true;
+        }),
+      );
+
+      const created1 = await service.createHttpService(node.id, serviceData1);
+      const created2 = await service.createHttpService(node.id, serviceData2);
+
+      expect(created1.backendHost).toEqual(sharedBackend.backendHost);
+      expect(created2.backendHost).toEqual(sharedBackend.backendHost);
+      expect(created1.backendPort).toEqual(sharedBackend.backendPort);
+      expect(created2.backendPort).toEqual(sharedBackend.backendPort);
+
+      expect(mockSaveToFile).toHaveBeenCalledWith(
+        `/etc/nginx/locations/${serviceData1.domain}/__main.conf`,
+        expect.stringContaining(
+          `${serviceData1.backendProto}://$node${node.id}service${created1.id}:${serviceData1.backendPort}`,
+        ),
+      );
+      expect(mockSaveToFile).toHaveBeenCalledWith(
+        `/etc/nginx/locations/${serviceData2.domain}/__main.conf`,
+        expect.stringContaining(
+          `${serviceData2.backendProto}://$node${node.id}service${created2.id}:${serviceData2.backendPort}`,
+        ),
+      );
+    });
   });
 
   describe('Update HTTP Service', () => {


### PR DESCRIPTION
## Summary

This change removes the HTTP-service backend uniqueness constraint so multiple HTTP services can point to the same backend host/port on the same node. The public `domain + pathLocation` uniqueness remains unchanged.

This is useful for setups like Traefik, where many domains should route to the same internal reverse proxy.

## Changes

- Removed the HTTP backend-target unique index from the entity.
- Added a migration/seeder to drop the old `service_port_unique` index for existing installs.
- Added a regression test proving multiple HTTP services can share the same backend.
- Updated frontend copy to reflect the shared-upstream model more clearly.

## Verification

- `PRIVATE_KEY=super_secret npx jest src/tests/nodes/http-services-service.test.ts --runInBand --detectOpenHandles`
- `npx tsc -p tsconfig.json --noEmit`