### PR TITLE
fix Oops typo

### DIFF
--- a/docker/resources/nginx/error_pages/404.html
+++ b/docker/resources/nginx/error_pages/404.html
@@ -51,7 +51,7 @@
   </style>
 </head>
 <body>
-  <h1>Ops! 404 — Not Found</h1>
+  <h1>Oops! 404 — Not Found</h1>
   <p>The requested page or service could not be found at this address. Please check the URL or contact the administrator.</p>
   <div class="footer">Powered by <strong>Wiredoor</strong></div>
 </body>

--- a/docker/resources/nginx/error_pages/502.html
+++ b/docker/resources/nginx/error_pages/502.html
@@ -51,7 +51,7 @@
   </style>
 </head>
 <body>
-    <h1>Ops! 502 — Bad Gateway</h1>
+    <h1>Oops! 502 — Bad Gateway</h1>
     <p>Wiredoor was unable to reach the backend service. The service may be down or misconfigured. Please try again later.</p>
     <div class="footer">Powered by <strong>Wiredoor</strong></div>
 </body>

--- a/docker/resources/nginx/error_pages/503.html
+++ b/docker/resources/nginx/error_pages/503.html
@@ -51,7 +51,7 @@
   </style>
 </head>
 <body>
-    <h1>Ops! 503 — Service Unavailable</h1>
+    <h1>Oops! 503 — Service Unavailable</h1>
     <p>The service is temporarily unavailable. This may be due to maintenance or high load. Please try again shortly.</p>
     <div class="footer">Powered by <strong>Wiredoor</strong></div>
 </body>

--- a/docker/resources/nginx/error_pages/504.html
+++ b/docker/resources/nginx/error_pages/504.html
@@ -51,7 +51,7 @@
   </style>
 </head>
 <body>
-    <h1>Ops! 504 — Gateway Timeout</h1>
+    <h1>Oops! 504 — Gateway Timeout</h1>
     <p>The backend service did not respond in time. This may be a temporary issue. Please check back later.</p>
     <div class="footer">Powered by <strong>Wiredoor</strong></div>
 </body>

--- a/docker/resources/nginx/error_pages/50x.html
+++ b/docker/resources/nginx/error_pages/50x.html
@@ -51,7 +51,7 @@
   </style>
 </head>
 <body>
-    <h1>Ops! 502 — Bad Gateway</h1>
+    <h1>Oops! 502 — Bad Gateway</h1>
     <p>Wiredoor was unable to reach the backend service. The service may be down or misconfigured. Please try again later.</p>
     <div class="footer">Powered by <strong>Wiredoor</strong></div>
 </body>


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

After spending a little too much time with a bad configuration, the typo on the error pages started getting to me.... 😄 

Brief description of the change:

Fix Ops -> Oops for error pages.

The 50x error page actually mentions error 502 in specific, maybe this should be generalized? 
I don't do a lot of web development so I don't know if it's appropriate to make the error for 50x more generic.

## Checklist

- [x ] Code compiles and runs correctly
- [x ] Linting and formatting pass
- [x ] Tests have been added/updated (if applicable)
- [x ] Docs have been updated (if applicable)
