### PR TITLE
fix(tcp): add SSL termination for TCP streams

### DIFF
--- a/docker/resources/nginx/partials/stream_ssl.conf
+++ b/docker/resources/nginx/partials/stream_ssl.conf
@@ -1,1 +1,1 @@
-proxy_ssl_config off;
+ssl_protocols TLSv1.2 TLSv1.3;

--- a/src/services/proxy-server/nginx-tcp-service.ts
+++ b/src/services/proxy-server/nginx-tcp-service.ts
@@ -41,7 +41,9 @@ export class NginxTcpService extends NginxService {
     }
 
     serverConf
-      .setListen(`${service.port}${service.proto === 'udp' ? ' udp' : ''}`)
+      .setListen(
+        `${service.port}${service.proto === 'udp' ? ' udp' : service.ssl ? ' ssl' : ''}`,
+      )
       .setServerName(service.domain || '')
       .setAccessLog(
         ServerUtils.getLogFilePath(

--- a/src/tests/nodes/tcp-services-service.test.ts
+++ b/src/tests/nodes/tcp-services-service.test.ts
@@ -282,6 +282,13 @@ describe('TCP Services Service', () => {
         ],
       ]);
 
+      const streamConfig = mockSaveToFile.mock.calls[2][1] as string;
+
+      expect(streamConfig).toMatch(
+        new RegExp(`listen\\s+${result.port} ssl;`),
+      );
+      expect(streamConfig).toMatch(/include\s+partials\/stream_ssl\.conf;/);
+
       expect(mockCLIExec.mock.calls).toEqual([
         [
           expect.stringMatching(


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Adds proper TLS configuration for TCP services with SSL enabled.

- Adds the ssl parameter to the Nginx stream listen directive.
- Load dedicated stream SSL partial supporting TLS 1.2 and TLS 1.3.
- Adds focused tests for both generated Nginx directives.

This PR fixes SSL termination configuration for TCP services.

---

## Related Issues

Closes #160 

---

## Checklist

- [x] Code compiles and runs correctly
- [x] Linting and formatting pass
- [x] Tests have been added/updated (if applicable)
- [ ] Docs have been updated (if applicable)
