### PR TITLE
161 extend port range useability

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This guide will help you get Wiredoor running and expose your first private serv
 - Linux VPS (recommended)
 - Docker Engine or Docker Desktop
 - Open ports: `80`, `443`, and a UDP port for the VPN (default `51820`)
-- Optional: Port range for exposing TCP services (e.g. `32760-32767`)
+- Optional: Port range and/or additional ports for exposing TCP services (e.g. `32760-32767` and `1883,8883,5432,5683,5684`)
 
 ## Deploy Wiredoor Server to your remote server
 
@@ -84,8 +84,8 @@ cp .env.example .env
 nano .env
 ```
 
-Set your admin email, password, VPN public hostname or IP, and optionally, the TCP port range.
-If you modify the TCP port range, make sure to update the `ports:` section in `docker-compose.yml`.
+Set your admin email, password, VPN public hostname or IP, and optionally, `TCP_SERVICES_PORT_RANGE`, `ADDITIONAL_TCP_SERVICES_PORTS`, or both.
+Make sure every configured TCP service port is also published in the `ports:` section of `docker-compose.yml`.
 
 ### Start Wiredoor Server
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,15 +1,16 @@
 # Wiredoor admin credentials
 ADMIN_EMAIL=admin@example.com           # Required. Also used by certbot if SSL is enabled
 ADMIN_PASSWORD=ChangeMe1st!             # Required. Use a secure password
- 
+
 # VPN Information
 VPN_HOST=public_host_or_ip              # Required. Public address that clients will connect to
 VPN_PORT=51820                          # Default WireGuard UDP port
 VPN_SUBNET=10.0.0.0/24                  # Subnet for clients (in CIDR format)
- 
+
 # TCP Port range
 TCP_SERVICES_PORT_RANGE=32760-32767     # Optional. Port range to expose TCP/UDP services
- 
+ADDITIONAL_TCP_SERVICES_PORTS=1883,5683 # Optional. Additional TCP/UDP service ports
+
 # TCP/UDP Exposure (Public Port Range)
 TZ=America/New_York                     # Time zone (recommended for logging)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,5 +16,7 @@ services:
       - 443:443/tcp
       - 51820:51820/udp                        # Must match with VPN_PORT in .env
     #      - 32760-32767                       # Must match with TCP_SERVICES_PORT_RANGE in .env
+    #      - 1883:1883/tcp                     # Must match a port in ADDITIONAL_TCP_SERVICES_PORTS
+    #      - 5683:5683/udp                     # Must match a port in ADDITIONAL_TCP_SERVICES_PORTS
     sysctls:
       - net.ipv4.ip_forward=1

--- a/documentation/configuration.mdx
+++ b/documentation/configuration.mdx
@@ -50,6 +50,8 @@ To enable GoDaddy DNS integration, set the following environment variables:
 |----------|-------------|----------|---------|
 | `PRIVATE_KEY` | Private key to issue tokens, auto-generated for each environment by default |  ❌ Optional | `htcVZnbD7yp8+z1R3vb6ww...gNrKNc/C7fkbHwBbw6uzIX61wLzlYg==` |
 | `SERVER_LOGS_DIR` | Custom directory to store nginx logs inside the container | ❌ Optional | `/var/log/nginx` |
+| `TCP_SERVICES_PORT_RANGE` | Port or port range available for exposing TCP/UDP services | ❌ Optional | `32760-32767` |
+| `ADDITIONAL_TCP_SERVICES_PORTS` | Comma-separated list of additional ports available for exposing TCP/UDP services | ❌ Optional | `32768,32770` |
 ---
 
 ## Volumes
@@ -70,8 +72,13 @@ To enable GoDaddy DNS integration, set the following environment variables:
 | `443` | TCP | HTTPS traffic |
 | `51820` (default) | UDP | WireGuard VPN connection |
 | `32760-32767` (optional) | TCP | Port range for exposing TCP services (controlled via `TCP_SERVICES_PORT_RANGE`) |
+| `32768,32770` (optional) | TCP | Additional ports for exposing TCP services (controlled via `ADDITIONAL_TCP_SERVICES_PORTS`) |
 
-You can change the VPN port or the TCP service range, but make sure those ports are **open and accessible** from the internet or from the client network.
+You can configure `TCP_SERVICES_PORT_RANGE`, `ADDITIONAL_TCP_SERVICES_PORTS`, or both. Wiredoor selects an available port from the range first. If the range is exhausted or not configured, it uses the first available additional port in the configured order.
+
+An explicitly selected public port must belong to the range or the additional list and must not already be assigned or in use locally. Additional ports cannot include `80`, `443`, the application port, the WireGuard VPN port, or the OAuth2 proxy range (`4180-4279`).
+
+Make sure every configured port is **open and accessible** from the internet or from the client network and published by your container runtime using the required TCP or UDP protocol.
 
 ---
 

--- a/documentation/faq.mdx
+++ b/documentation/faq.mdx
@@ -134,7 +134,7 @@ or
 wiredoor tcp my-ssh --port 22 
 ```
 
-Wiredoor assign unused port automatically in the range defined by `TCP_SERVICES_PORT_RANGE`
+Wiredoor first assigns an available port from `TCP_SERVICES_PORT_RANGE`. If the range is exhausted or not configured, it uses the first available port from `ADDITIONAL_TCP_SERVICES_PORTS` in the configured order.
 
 ---
 

--- a/documentation/quickstart.mdx
+++ b/documentation/quickstart.mdx
@@ -24,7 +24,7 @@ This guide will help you get Wiredoor running and expose your first private serv
 - ✅ Open ports:
   - TCP: `80`, `443` — for HTTP and HTTPS traffic
   - UDP: `51820` — for WireGuard VPN (configurable)
-  - Optional: a range of ports for exposing TCP services
+  - Optional: a port range and/or a list of additional ports for exposing TCP services
 - ✅ Installed:
   - [Docker Engine](https://docs.docker.com/engine/install/)
   - (Optionally) [Docker Compose](https://docs.docker.com/compose/)
@@ -47,8 +47,8 @@ cp .env.example .env
 nano .env
 ```
 
-Set your admin email, password, VPN public hostname or IP, and optionally, the TCP port range.
-If you modify the TCP port range, make sure to update the `ports:` section in `docker-compose.yml`.
+Set your admin email, password, VPN public hostname or IP, and optionally, `TCP_SERVICES_PORT_RANGE`, `ADDITIONAL_TCP_SERVICES_PORTS`, or both.
+Make sure every configured TCP service port is also published in the `ports:` section of `docker-compose.yml`.
 
 ### Start Wiredoor Server
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,7 +9,27 @@ dotenv.config();
 const defaultAdminEmail = 'admin@example.com';
 const defaultAdminPassword = 'ChangeMe1st!';
 
+const APP_PORT = parseInt(process.env.APP_PORT || '') || 3000;
 const VPN_PORT = process.env.VPN_PORT || '51820';
+const ADDITIONAL_TCP_SERVICES_PORTS = process.env.ADDITIONAL_TCP_SERVICES_PORTS;
+export const OAUTH2_PROXY_PORT_MIN = 4180;
+export const OAUTH2_PROXY_PORT_MAX = 4279;
+
+const reservedPorts = new Set([80, 443, APP_PORT, +VPN_PORT]);
+const reservedAdditionalPort = ADDITIONAL_TCP_SERVICES_PORTS?.split(',')
+  .map(Number)
+  .find(
+    (port) =>
+      reservedPorts.has(port) ||
+      (port >= OAUTH2_PROXY_PORT_MIN && port <= OAUTH2_PROXY_PORT_MAX),
+  );
+
+if (reservedAdditionalPort) {
+  throw new Error(
+    `ADDITIONAL_TCP_SERVICES_PORTS cannot include reserved port ${reservedAdditionalPort}.`,
+  );
+}
+
 const subnet = process.env.VPN_SUBNET || '10.0.0.0/24';
 const defaultPreUpScript = ``;
 const defaultPostUpScript = `
@@ -74,7 +94,7 @@ function requireAdminPasswordEnv(): string {
 export default {
   app: {
     name: process.env.APP_NAME || 'Wiredoor',
-    port: parseInt(process.env.APP_PORT || '') || 3000,
+    port: APP_PORT,
   },
   log: {
     level: process.env.LOG_LEVEL || 'info',
@@ -98,6 +118,7 @@ export default {
   },
   server: {
     port_range: process.env.TCP_SERVICES_PORT_RANGE,
+    additional_ports: ADDITIONAL_TCP_SERVICES_PORTS,
   },
   dns: {
     provider: process.env.DNS_PROVIDER || null,

--- a/src/repositories/domain-repository.ts
+++ b/src/repositories/domain-repository.ts
@@ -5,6 +5,7 @@ import BaseRepository from './base-repository';
 import Net from '../utils/net';
 import { ValidationError } from '../utils/errors/validation-error';
 import { Logger } from '../logger';
+import { OAUTH2_PROXY_PORT_MAX, OAUTH2_PROXY_PORT_MIN } from '../config';
 
 @Service()
 export class DomainRepository extends BaseRepository<Domain> {
@@ -17,8 +18,8 @@ export class DomainRepository extends BaseRepository<Domain> {
   }
 
   async getAvailablePort(): Promise<number> {
-    const min = 4180;
-    const max = 5180;
+    const min = OAUTH2_PROXY_PORT_MIN;
+    const max = OAUTH2_PROXY_PORT_MAX;
 
     const servicePorts = await this.createQueryBuilder('domain')
       .select('domain.oauth2ServicePort')

--- a/src/repositories/tcp-service-repository.ts
+++ b/src/repositories/tcp-service-repository.ts
@@ -11,44 +11,85 @@ export class TcpServiceRepository extends Repository<TcpService> {
     super(TcpService, dataSource.createEntityManager());
   }
 
+  async assertPortAvailable(port: number, serviceId?: number): Promise<void> {
+    const query = this.createQueryBuilder('tcpService').where(
+      'tcpService.port = :port',
+      { port },
+    );
+
+    if (serviceId) {
+      query.andWhere('tcpService.id != :serviceId', { serviceId });
+    }
+
+    const isUsed =
+      (await query.getCount()) > 0 ||
+      (await Net.checkPort('127.0.0.1', port, null, null, 500));
+
+    if (isUsed) {
+      throw new ValidationError({
+        body: [{ field: 'port', message: `Port ${port} is already in use.` }],
+      });
+    }
+  }
+
   async getAvailablePort(): Promise<number> {
-    if (!config.server.port_range) {
+    if (!config.server.port_range && !config.server.additional_ports) {
       throw new ValidationError({
         body: [
           {
             field: 'port',
             message:
-              'Your servers needs TCP_SERVICES_PORT_RANGE env variable defined.',
+              'Your servers needs TCP_SERVICES_PORT_RANGE or ADDITIONAL_TCP_SERVICES_PORTS env variable defined.',
           },
         ],
       });
     }
-
-    const min = +config.server.port_range.split('-')[0];
-    const max =
-      +config.server.port_range.split('-').length == 2
-        ? +config.server.port_range.split('-')[1]
-        : min;
 
     const servicePorts = await this.createQueryBuilder('tcpService')
-      .select('tcpService.port')
+      .select('tcpService.port', 'port')
       .getRawMany();
+    const usedPorts = servicePorts.map((service) => +service.port);
+    const additionalPorts = config.server.additional_ports
+      ? config.server.additional_ports.split(',').map((p) => +p)
+      : [];
 
-    try {
-      return Net.getAvailableLocalPort(
-        servicePorts.map((s) => s.port),
-        min,
-        max,
-      );
-    } catch (e: any) {
-      throw new ValidationError({
-        body: [
-          {
-            field: 'port',
-            message: e.message,
-          },
-        ],
-      });
+    if (config.server.port_range) {
+      const [min, configuredMax] = config.server.port_range
+        .split('-')
+        .map((p) => +p);
+      const max = configuredMax || min;
+
+      try {
+        const port = await Net.getAvailableLocalPort(usedPorts, min, max);
+        if (port) return port;
+      } catch (error) {
+        if (!additionalPorts.length) {
+          throw new ValidationError({
+            body: [
+              {
+                field: 'port',
+                message: error instanceof Error ? error.message : String(error),
+              },
+            ],
+          });
+        }
+      }
     }
+
+    for (const port of additionalPorts) {
+      if (usedPorts.includes(port)) continue;
+
+      const isUsed = await Net.checkPort('127.0.0.1', port, null, null, 500);
+      if (!isUsed) return port;
+    }
+
+    throw new ValidationError({
+      body: [
+        {
+          field: 'port',
+          message: 'No ports available to expose your service.',
+        },
+      ],
+    });
   }
 }

--- a/src/services/tcp-services-service.ts
+++ b/src/services/tcp-services-service.ts
@@ -89,6 +89,8 @@ export class TcpServicesService extends BaseServices {
       const port = await this.tcpServiceRepository.getAvailablePort();
 
       params.port = port;
+    } else {
+      await this.tcpServiceRepository.assertPortAvailable(params.port);
     }
 
     const expiresAt = calculateExpiresAtFromTTL(params.ttl);
@@ -116,6 +118,10 @@ export class TcpServicesService extends BaseServices {
     params: Partial<TcpServiceType>,
   ): Promise<TcpService> {
     const old = await this.getTcpService(id, ['node']);
+
+    if (params.port && params.port !== old.port) {
+      await this.tcpServiceRepository.assertPortAvailable(params.port, id);
+    }
 
     if (params.backendPort && params.backendHost && params.proto === 'tcp') {
       await this.checkNodePort(

--- a/src/tests/nodes/tcp-services-service.test.ts
+++ b/src/tests/nodes/tcp-services-service.test.ts
@@ -15,6 +15,7 @@ import { makeTcpServiceData } from './stubs/tcp-service.stub';
 import {
   mockCheckPort,
   mockCLIExec,
+  mockGetAvailablePort,
   mockIsPath,
   mockNslookup,
   mockRemoveFile,
@@ -35,6 +36,8 @@ import { PagedData } from '../../repositories/filters/repository-query-filter';
 import { faker } from '@faker-js/faker';
 import { Server } from 'http';
 import ServerUtils from '../../utils/server';
+import config from '../../config';
+import { ValidationError } from '../../utils/errors/validation-error';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 let app;
@@ -114,10 +117,53 @@ describe('TCP Services Service', () => {
     );
 
     jest.clearAllMocks();
+    (mockCheckPort as jest.Mock).mockImplementation(
+      (host: string) => host !== '127.0.0.1',
+    );
   });
 
   afterEach(async () => {
     jest.clearAllMocks();
+  });
+
+  describe('Available port', () => {
+    const portRange = config.server.port_range;
+    const additionalPorts = config.server.additional_ports;
+
+    afterEach(() => {
+      config.server.port_range = portRange;
+      config.server.additional_ports = additionalPorts;
+    });
+
+    it('should prefer an available port from the configured range', async () => {
+      config.server.port_range = '15000-15001';
+      config.server.additional_ports = '16001';
+      mockGetAvailablePort.mockReturnValueOnce(15001);
+
+      await expect(repository.getAvailablePort()).resolves.toBe(15001);
+    });
+
+    it('should use the first additional port available in the database and locally', async () => {
+      config.server.port_range = '15000-15000';
+      config.server.additional_ports = '16001,16002,16003';
+
+      const occupiedService = await repository.save({
+        ...makeTcpServiceData({ port: 16001 }),
+        port: 16001,
+        nodeId: node.id,
+      });
+
+      try {
+        mockGetAvailablePort.mockImplementationOnce(() => {
+          throw new Error('No ports available in range');
+        });
+        mockCheckPort.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+        await expect(repository.getAvailablePort()).resolves.toBe(16003);
+      } finally {
+        await repository.delete(occupiedService.id);
+      }
+    });
   });
 
   describe('Initialization', () => {
@@ -244,6 +290,33 @@ describe('TCP Services Service', () => {
   });
 
   describe('Create TCP Service', () => {
+    it('should reject an explicit port occupied locally', async () => {
+      const serviceData = makeTcpServiceData({ proto: 'udp', port: 15500 });
+      mockCheckPort.mockReturnValue(true);
+
+      await expect(
+        service.createTcpService(node.id, serviceData),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    it('should reject an explicit port assigned to another service', async () => {
+      const port = 15501;
+      await repository.save({
+        ...makeTcpServiceData({ port }),
+        port,
+        nodeId: node.id,
+      });
+      const serviceData = makeTcpServiceData({
+        proto: 'udp',
+        port,
+        backendPort: 9000,
+      });
+
+      await expect(
+        service.createTcpService(node.id, serviceData),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+
     it('should create TCP Service and save server configuration file', async () => {
       const serviceData = makeTcpServiceData({ ssl: true });
 
@@ -284,9 +357,7 @@ describe('TCP Services Service', () => {
 
       const streamConfig = mockSaveToFile.mock.calls[2][1] as string;
 
-      expect(streamConfig).toMatch(
-        new RegExp(`listen\\s+${result.port} ssl;`),
-      );
+      expect(streamConfig).toMatch(new RegExp(`listen\\s+${result.port} ssl;`));
       expect(streamConfig).toMatch(/include\s+partials\/stream_ssl\.conf;/);
 
       expect(mockCLIExec.mock.calls).toEqual([
@@ -361,6 +432,22 @@ describe('TCP Services Service', () => {
   });
 
   describe('Update TCP Service', () => {
+    it('should reject changing to a port occupied locally', async () => {
+      const created = await repository.save({
+        ...makeTcpServiceData({ port: 15502 }),
+        port: 15502,
+        nodeId: node.id,
+      });
+      mockCheckPort.mockReturnValue(true);
+
+      await expect(
+        service.updateTcpService(created.id, {
+          ...makeTcpServiceData({ proto: 'udp', port: 15503 }),
+          port: 15503,
+        }),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+
     it('should update TCP Service and save server configuration file', async () => {
       const serviceData = makeTcpServiceData();
 

--- a/src/validators/tcp-service-validator.ts
+++ b/src/validators/tcp-service-validator.ts
@@ -27,6 +27,28 @@ export interface TcpServiceFilterQueryParams extends FilterQueryDto {
   domain?: string;
 }
 
+const tcpServicePortValidator = Joi.number()
+  .integer()
+  .min(1)
+  .max(65535)
+  .custom((port, helpers) => {
+    const [min, configuredMax] = config.server.port_range
+      ? config.server.port_range.split('-').map(Number)
+      : [];
+    const max = configuredMax || min;
+    const additionalPorts = config.server.additional_ports
+      ? config.server.additional_ports.split(',').map(Number)
+      : [];
+
+    if ((min && port >= min && port <= max) || additionalPorts.includes(port)) {
+      return port;
+    }
+
+    return helpers.message({
+      custom: `Port ${port} is not within the allowed range`,
+    });
+  });
+
 export const tcpServiceFilterValidator: ObjectSchema<TcpServiceFilterQueryParams> =
   Joi.object({
     limit: Joi.number().optional(),
@@ -51,16 +73,7 @@ export const tcpServiceValidator: ObjectSchema<TcpServiceType> = Joi.object({
     .invalid('localhost', '127.0.0.1')
     .optional(),
   backendPort: Joi.number().port().required(),
-  port: Joi.number()
-    .min(config.server.port_range ? +config.server.port_range.split('-')[0] : 0)
-    .max(
-      config.server.port_range
-        ? +config.server.port_range.split('-')[1]
-          ? +config.server.port_range.split('-')[1]
-          : +config.server.port_range.split('-')[0]
-        : 0,
-    )
-    .optional(),
+  port: tcpServicePortValidator.optional(),
   ssl: Joi.boolean().optional(),
   allowedIps: Joi.array()
     .items(Joi.string().ip({ cidr: 'optional' }).optional())


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Adds support for configuring additional public ports for TCP/UDP services through `ADDITIONAL_TCP_SERVICES_PORTS`.

- Prefers ports from `TCP_SERVICES_PORT_RANGE` during automatic assignment.
- Falls back to the first available additional port when the range is unavailable or exhausted.
- Rejects explicit ports that are outside the configured range/list or already in use.
- Prevents reserved Wiredoor, WireGuard, application, and OAuth2 Proxy ports from being configured as additional ports.
- Updates the configuration, quickstart, FAQ, README, and Docker examples.

---

## Related Issues

Closes #161 

---

## Checklist

- [x] Code compiles and runs correctly
- [x] Linting and formatting pass
- [x] Tests have been added/updated (if applicable)
- [x] Docs have been updated (if applicable)
